### PR TITLE
Remove dialyzer

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -43,8 +43,6 @@
          delete_each/1
         ]).
 
--dialyzer({no_missing_calls, escript_foldl/3}).
-
 -include("rebar.hrl").
 
 %% ====================================================================


### PR DESCRIPTION
Currently unable to build `enc` with dialyzer line on OTP 23. This PR aims to allow building on OTP 23.